### PR TITLE
fix: resolve password mismatch, WebSocket protocol, duplicate buttons

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -278,7 +278,7 @@ exec startxfce4
 VNC_EOF
     chmod +x ~/.vnc/xstartup
 
-    printf '\n\n' | vncpasswd -f > ~/.vnc/passwd 2>/dev/null || true
+    printf '\ncloudlinux\ncloudlinux\n' | vncpasswd -f > ~/.vnc/passwd 2>/dev/null || true
     chmod 600 ~/.vnc/passwd
 
     print_success "VNC configured"

--- a/web/vnc.html
+++ b/web/vnc.html
@@ -238,7 +238,6 @@
         <button class="btn" onclick="sendCtrlAltDel()" title="Ctrl+Alt+Del">⌨️</button>
         <button class="btn" onclick="toggleKeyboard()" title="Toggle Keyboard">⌨️</button>
         <button class="btn" onclick="refresh()" title="Refresh">🔄</button>
-        <button class="btn" onclick="showKeyboard()" title="Keyboard">⌨️</button>
     </div>
 
     <div id="mobile-keys">
@@ -278,7 +277,9 @@
             const port = window.location.port || (window.location.protocol === 'https:' ? 443 : 80);
 
             try {
-                const url = `wss://${host}:${port}/websockify`;
+                const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+            const port = window.location.port || (window.location.protocol === 'https:' ? 443 : 80);
+            const url = `${proto}//${host}:${port}/websockify`;
                 rfb = new RFB(screen, url, {
                     credentials: { password: 'cloudlinux' },
                     reconnect: true,


### PR DESCRIPTION
## Summary
- Fixes #1: Set VNC password to 'cloudlinux' in install.sh to match vnc.html
- Fixes #2: Use dynamic ws/wss protocol based on page protocol
- Fixes #3: Remove duplicate keyboard toggle button

## Changes
1. **install.sh:281** - Set password to 'cloudlinux' 
2. **vnc.html:281** - Use dynamic protocol instead of hardcoded wss://
3. **vnc.html:241** - Removed duplicate keyboard button