### PR TITLE
fix: add missing xvfb package to dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -56,12 +56,23 @@ install_dependencies() {
         apt-get install -y \
             xfce4 xfce4-goodies xorg dbus-x11 \
             tigervnc-standalone-server tigervnc-common \
+            xvfb x11-apps x11-utils \
             websockify \
             curl wget git nano vim \
             fonts-noto-cjk 2>/dev/null || true
     elif command -v yum &> /dev/null; then
         yum install -y \
-            xfce4-session dbus-x11 tigervnc-server websockify \
+            xfce4-session dbus-x11 tigervnc-server \
+            xorg-x11-server-Xvfb \
+            xorg-x11-apps xorg-x11-utils \
+            websockify \
+            curl wget git nano vim 2>/dev/null || true
+    elif command -v dnf &> /dev/null; then
+        dnf install -y \
+            xfce4-session dbus-x11 tigervnc-server \
+            xorg-x11-server-Xvfb \
+            xorg-x11-apps xorg-x11-utils \
+            websockify \
             curl wget git nano vim 2>/dev/null || true
     fi
     print_success "Dependencies installed"


### PR DESCRIPTION
## Summary
Fixes the `[✗] Failed to start Xvfb` error during installation by adding missing Xvfb packages to dependencies.

## Changes
- Add `xvfb`, `x11-apps`, `x11-utils` to apt-get dependencies
- Add `xorg-x11-server-Xvfb`, `xorg-x11-apps`, `xorg-x11-utils` to yum dependencies  
- Add missing dnf package manager support for Fedora/RHEL 8+

## Testing
The fix resolves the Xvfb startup failure when running:
```bash
curl -sL https://raw.githubusercontent.com/unn-known1/cloud-linux-gui/main/install.sh | bash
```