### PR TITLE
fix(security): remove hardcoded VNC password (#23)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,9 @@ exec dbus-launch --exit-with-session startxfce4
 XEOF
 chmod +x /root/.vnc/xstartup
 
-VNC_PASS="desktop123"
+# Generate a secure random VNC password
+# SECURITY: Use a randomly generated password instead of hardcoded value
+VNC_PASS=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9' | head -c 16)
 
 echo "${VNC_PASS}" | vncpasswd -f > /root/.vnc/passwd 2>/dev/null
 if [ ! -s /root/.vnc/passwd ]; then


### PR DESCRIPTION
## Summary

Replaces hardcoded VNC password with dynamically generated secure password.
## Changes

- Uses openssl for cryptographically secure random password generation
- 16-character alphanumeric password
- Password stored securely with 600 permissions

## Security

CWE-798 (Use of Hard-coded Credentials)
Closes #23