### PR TITLE
Fix: recreate PID directory after cleanup_all deletes it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,7 @@ cleanup_all() {
 
 # Clean up orphaned processes from a prior run (by PID file, not by name)
 cleanup_all 2>/dev/null || true
+mkdir -p "$PID_DIR"
 rm -f /tmp/.X*-lock 2>/dev/null || true
 rm -rf /tmp/.X11-unix/X* 2>/dev/null || true
 


### PR DESCRIPTION
## Summary\ncleanup_all runs rm -rf \$PID_DIR at startup, deleting the directory created at line 27. When save_pid is called later, the parent dir is gone causing 'No such file or directory' errors. Fix: recreate the directory after cleanup.